### PR TITLE
Prevent multiple loads for the same placement

### DIFF
--- a/Source/HyprMXAdapter.swift
+++ b/Source/HyprMXAdapter.swift
@@ -32,11 +32,15 @@ final class HyprMXAdapter: PartnerAdapter {
     /// The human-friendly partner name.
     let partnerDisplayName = "HyprMX"
 
+    /// Ad storage managed by Chartboost Mediation SDK.
+    let storage: PartnerAdapterStorage
+    
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.
     /// It includes a list of created `PartnerAd` instances. You may ignore this parameter if you don't need it.
     init(storage: PartnerAdapterStorage) {
+        self.storage = storage
     }
 
     /// Does any setup needed before beginning to load ads.
@@ -117,6 +121,16 @@ final class HyprMXAdapter: PartnerAdapter {
     /// - parameter request: Information about the ad load request.
     /// - parameter delegate: The delegate that will receive ad life-cycle notifications.
     func makeAd(request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) throws -> PartnerAd {
+        // Prevent multiple loads for the same partner placement, since the partner SDK cannot handle them.
+        // Banner loads are allowed so a banner prefetch can happen during auto-refresh.
+        // ChartboostMediationSDK 4.x does not support loading more than 2 banners with the same placement, and the partner may or may not support it.
+        guard !storage.ads.contains(where: { $0.request.partnerPlacement == request.partnerPlacement })
+            || request.format == .banner
+        else {
+            log("Failed to load ad for already loading placement \(request.partnerPlacement)")
+            throw error(.loadFailureLoadInProgress)
+        }
+        
         switch request.format {
         case .banner:
             return HyprMXAdapterBannerAd(adapter: self, request: request, delegate: delegate)


### PR DESCRIPTION
I tested this and found that when assigning a placementDelegate to the `HyprMXPlacement` overrides previous values set by ads with the same placement.
So loading multiple fullscreen ads means only the last one receives delegate calls.
This was easily reproducible by loading 3 ads, showing the first one, and seeing that the show fails with a timeout: the adWillStart callback was never called for the first ad, it was called on the 3rd one which was not shown.