### PR TITLE
Un-revert 'Update Version to 4.6.2.0.1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.6.2.0.1
+- Pass COPPA setting HyprMX at startup.
+- Add logging for changes to privacy consent status.
+- Fix missing callback when banner ads are clicked.
+- This version of the adapters has been certified with HyprMX 6.2.0.
+
 ### 4.6.2.0.0
 - Fixed partner SDK version to match the value reported by the SDK.
 - This version of the adapters has been certified with HyprMX 6.2.0.

--- a/ChartboostMediationAdapterHyprMX.podspec
+++ b/ChartboostMediationAdapterHyprMX.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterHyprMX'
-  spec.version     = '4.6.2.0.0'
+  spec.version     = '4.6.2.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-hyprmx'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }

--- a/Source/HyprMXAdapter.swift
+++ b/Source/HyprMXAdapter.swift
@@ -209,12 +209,12 @@ extension HyprMXAdapter: HyprMXInitializationDelegate {
 
 extension HyprConsentStatus {
     var description: String {
-        switch self.rawValue {
-        case 0:
+        switch self {
+        case CONSENT_STATUS_UNKNOWN:
             return "CONSENT_STATUS_UNKNOWN"
-        case 1:
+        case CONSENT_GIVEN:
             return "CONSENT_GIVEN"
-        case 2:
+        case CONSENT_DECLINED:
             return "CONSENT_DECLINED"
         default:
             return "undefined consent status"

--- a/Source/HyprMXAdapter.swift
+++ b/Source/HyprMXAdapter.swift
@@ -8,6 +8,7 @@ import HyprMX
 
 final class HyprMXAdapter: PartnerAdapter {
 
+    private let AGE_RESTRICTED_USER_KEY = "com.chartboost.adapter.hyprmx.ageRestrictedUser"
     private let DISTRIBUTOR_ID_KEY = "distributor_id"
     private let GAMEID_STORAGE_KEY = "com.chartboost.adapter.hyprmx.game_id"
     // We track "has opted out" instead of "has opted in" because it makes the
@@ -25,7 +26,7 @@ final class HyprMXAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.6.2.0.0"
+    let adapterVersion = "4.6.2.0.1"
 
     /// The partner's unique identifier.
     let partnerIdentifier = "hyprmx"
@@ -65,11 +66,17 @@ final class HyprMXAdapter: PartnerAdapter {
             UserDefaults.standard.set(gameID, forKey: GAMEID_STORAGE_KEY)
         }
 
+        // UserDefaults.standard.bool defaults to false if key is not present
+        let savedAgeRestrictedUserSetting = UserDefaults.standard.bool(forKey: AGE_RESTRICTED_USER_KEY)
         // HyprMX.initialize() uses WKWebView, which must only be used on the main thread
         DispatchQueue.main.async { [self] in
+            // consentStatus will be updated by setGDPR & setCCPA after init
             HyprMX.initialize(withDistributorId: distributorId,
                               userId: gameID,
+                              consentStatus: CONSENT_STATUS_UNKNOWN,
+                              ageRestrictedUser: savedAgeRestrictedUserSetting,
                               initializationDelegate: self)
+            // For information about these init options, see https://documentation.hyprmx.com/ios-hyprmx-sdk/#initialization-api
         }
     }
 
@@ -116,6 +123,12 @@ final class HyprMXAdapter: PartnerAdapter {
     /// Indicates if the user is subject to COPPA or not.
     /// - parameter isChildDirected: `true` if the user is subject to COPPA, `false` otherwise.
     func setCOPPA(isChildDirected: Bool) {
+        // We map the COPPA setting to HyprMX's ageRestrictedUser setting based on their description
+        // of its intended use, for instance "If the user requires child-directed treatment under
+        // applicable laws and policies, set this parameter to true."
+        // More info at https://documentation.hyprmx.com/ios-hyprmx-sdk/#initialization-api
+        UserDefaults.standard.set(isChildDirected, forKey: AGE_RESTRICTED_USER_KEY)
+        log(.privacyUpdated(setting: "ageRestrictedUser", value: isChildDirected))
     }
 
     /// Creates a new ad object in charge of communicating with a single partner SDK ad instance.
@@ -172,7 +185,9 @@ final class HyprMXAdapter: PartnerAdapter {
 
         // HyprMX only supports interaction from the Main Thread
         DispatchQueue.main.async { [self] in
-            HyprMX.setConsentStatus(determineConsentState())
+            let consentState = determineConsentState()
+            HyprMX.setConsentStatus(consentState)
+            log(.privacyUpdated(setting: "HyprConsentStatus", value: consentState.description))
         }
     }
 }
@@ -189,5 +204,20 @@ extension HyprMXAdapter: HyprMXInitializationDelegate {
         log(.setUpFailed(error))
         initializationCompletion?(error)
         initializationCompletion = nil
+    }
+}
+
+internal extension HyprConsentStatus {
+    var description: String {
+        switch self.rawValue {
+        case 0:
+            return "CONSENT_STATUS_UNKNOWN"
+        case 1:
+            return "CONSENT_GIVEN"
+        case 2:
+            return "CONSENT_DECLINED"
+        default:
+            return "undefined consent status"
+        }
     }
 }

--- a/Source/HyprMXAdapter.swift
+++ b/Source/HyprMXAdapter.swift
@@ -207,7 +207,7 @@ extension HyprMXAdapter: HyprMXInitializationDelegate {
     }
 }
 
-internal extension HyprConsentStatus {
+extension HyprConsentStatus {
     var description: String {
         switch self.rawValue {
         case 0:

--- a/Source/HyprMXAdapterBannerAd.swift
+++ b/Source/HyprMXAdapterBannerAd.swift
@@ -69,6 +69,7 @@ extension HyprMXAdapterBannerAd: HyprMXBannerDelegate {
     // Called when the user clicks on the bannerView
     func adWasClicked(_ bannerView: HyprMXBannerView) {
         log(.didClick(error: nil))
+        delegate?.didClick(self, details: [:]) ?? log(.delegateUnavailable)
     }
 
     // Called when a banner click will open another application


### PR DESCRIPTION
I accidentally merged the release/4.6.2.0.1 branch before the release candidate was approved, then reverted that merge.
This PR brings `main` into the same state the RC was generated from, and this can be confirmed by doing a diff between this branch and the commit hash (8cbe09d0731b9ae2bede25a4cbe69510820435ac) from [that run of Create Adapter Release Candidate](https://github.com/ChartBoost/ios-helium-sdk/actions/runs/5535483781)