### PR TITLE
[HB-6734] add privacy manifest

### DIFF
--- a/ChartboostMediationAdapterHyprMX.podspec
+++ b/ChartboostMediationAdapterHyprMX.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |spec|
   spec.module_name  = 'ChartboostMediationAdapterHyprMX'
   spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-hyprmx.git', :tag => spec.version }
   spec.source_files = 'Source/**/*.{swift}'
+  spec.resource_bundles = { 'ChartboostMediationAdapterHyprMX' => ['PrivacyInfo.xcprivacy'] }
 
   # Minimum supported versions
   spec.swift_version         = '5.0'

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Source/HyprMXAdapter.swift
+++ b/Source/HyprMXAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/HyprMXAdapterAd.swift
+++ b/Source/HyprMXAdapterAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/HyprMXAdapterBannerAd.swift
+++ b/Source/HyprMXAdapterBannerAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/HyprMXAdapterInterstitialAd.swift
+++ b/Source/HyprMXAdapterInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/HyprMXAdapterRewardedAd.swift
+++ b/Source/HyprMXAdapterRewardedAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Add a privacy manifest to declare `UserDefaults` usage (`NSPrivacyAccessedAPICategoryUserDefaults`).
![image](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-hyprmx/assets/122156786/335e0c2f-9435-4341-a7ea-538bebf8ed51)

There is no way to test this privacy manifest until it is publicly available, but we have until April 2023 to verify.