### PR TITLE
Fix the starting year of copyright header

### DIFF
--- a/Source/HyprMXAdapter.swift
+++ b/Source/HyprMXAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2023-2023 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/HyprMXAdapterAd.swift
+++ b/Source/HyprMXAdapterAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2023-2023 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/HyprMXAdapterBannerAd.swift
+++ b/Source/HyprMXAdapterBannerAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2023-2023 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/HyprMXAdapterInterstitialAd.swift
+++ b/Source/HyprMXAdapterInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2023-2023 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/HyprMXAdapterRewardedAd.swift
+++ b/Source/HyprMXAdapterRewardedAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2023-2023 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
HyprMX was added back in March 2023, but the copyright header uses 2022.

PR #16 fails the CI checks due to this mismatch:
```
Run ruby "/Users/runner/work/_actions/chartboost/chartboost-mediation-ios-actions/v1/adapter-smoke-test/../scripts/adapters/validate-adapter-version.rb"
Run ruby "/Users/runner/work/_actions/chartboost/chartboost-mediation-ios-actions/v1/adapter-smoke-test/../scripts/adapters/validate-copyright-headers.rb"
Validation failed: ./Source/HyprMXAdapter.swift does not have a proper copyright notice header.
Expected:
// Copyright 2023-2023 Chartboost, Inc.
//
// Use of this source code is governed by an MIT-style
// license that can be found in the LICENSE file.

Found:
// Copyright 2022-2023 Chartboost, Inc.
//
// Use of this source code is governed by an MIT-style
// license that can be found in the LICENSE file.
```