### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
             allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
             allow-warnings: true

--- a/Source/HyprMXAdapter.swift
+++ b/Source/HyprMXAdapter.swift
@@ -72,7 +72,7 @@ final class HyprMXAdapter: PartnerAdapter {
             gameID = ProcessInfo.processInfo.globallyUniqueString
             UserDefaults.standard.set(gameID, forKey: GAMEID_STORAGE_KEY)
         }
-
+        HyprMX.setLogLevel(HYPRLogLevelDebug)
         // HyprMX.initialize() uses WKWebView, which must only be used on the main thread
         DispatchQueue.main.async { [self] in
             // consentStatus will be updated by setGDPR & setCCPA after init

--- a/Source/HyprMXAdapter.swift
+++ b/Source/HyprMXAdapter.swift
@@ -20,18 +20,26 @@ final class HyprMXAdapter: PartnerAdapter {
     // MARK: PartnerAdapter
 
     /// The version of the partner SDK.
-    let partnerSDKVersion = HyprMX.versionString()
+    var partnerSDKVersion: String {
+        HyprMXAdapterConfiguration.partnerSDKVersion
+    }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.6.3.0.0"
+    var adapterVersion: String {
+        HyprMXAdapterConfiguration.adapterVersion
+    }
 
     /// The partner's unique identifier.
-    let partnerID = "hyprmx"
+    var partnerID: String {
+        HyprMXAdapterConfiguration.partnerID
+    }
 
     /// The human-friendly partner name.
-    let partnerDisplayName = "HyprMX"
+    var partnerDisplayName: String {
+        HyprMXAdapterConfiguration.partnerDisplayName
+    }
 
     /// Ad storage managed by Chartboost Mediation SDK.
     let storage: PartnerAdapterStorage

--- a/Source/HyprMXAdapterConfiguration.swift
+++ b/Source/HyprMXAdapterConfiguration.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import HyprMX
+import os.log
 
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class HyprMXAdapterConfiguration: NSObject {
@@ -28,8 +29,10 @@ import HyprMX
     /// Flag that can optionally be set to change the log level of the HyprMX SDK.
     @objc public static var logLevel: HYPRLogLevel = HYPRLogLevelError {
         didSet {
-            HyprMX.setLogLevel(newValue)
-            os_log(.debug, log: log, "HyprMX SDK log level set to %{public}s", "\(newValue)")
+            HyprMX.setLogLevel(logLevel)
+            os_log(.debug, log: log, "HyprMX SDK log level set to %{public}s", "\(logLevel)")
         }
     }
+
+    private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.hyprmx", category: "Configuration")
 }

--- a/Source/HyprMXAdapterConfiguration.swift
+++ b/Source/HyprMXAdapterConfiguration.swift
@@ -10,20 +10,20 @@ import HyprMX
 @objc public class HyprMXAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         HyprMX.versionString()
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.6.3.0.0"
+    @objc public static let adapterVersion = "4.6.3.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "hyprmx"
+    @objc public static let partnerID = "hyprmx"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "HyprMX"
+    @objc public static let partnerDisplayName = "HyprMX"
 
     /// Flag that can optionally be set to change the log level of the HyprMX SDK.
     @objc public static var logLevel: HYPRLogLevel = HYPRLogLevelError {

--- a/Source/HyprMXAdapterConfiguration.swift
+++ b/Source/HyprMXAdapterConfiguration.swift
@@ -1,0 +1,27 @@
+// Copyright 2022-2024 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import Foundation
+import HyprMX
+
+/// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
+@objc public class HyprMXAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        HyprMX.versionString()
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.6.3.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "hyprmx"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "HyprMX"
+}

--- a/Source/HyprMXAdapterConfiguration.swift
+++ b/Source/HyprMXAdapterConfiguration.swift
@@ -24,4 +24,12 @@ import HyprMX
 
     /// The human-friendly partner name.
     @objc static let partnerDisplayName = "HyprMX"
+
+    /// Flag that can optionally be set to change the log level of the HyprMX SDK.
+    @objc public static var logLevel: HYPRLogLevel = HYPRLogLevelError {
+        didSet {
+            HyprMX.setLogLevel(newValue)
+            os_log(.debug, log: log, "HyprMX SDK log level set to %{public}s", "\(newValue)")
+        }
+    }
 }


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.