### PR TITLE
HB-7607: Replace duplicated code with call to helper method

### DIFF
--- a/Source/HyprMXAdapterBannerAd.swift
+++ b/Source/HyprMXAdapterBannerAd.swift
@@ -21,7 +21,7 @@ final class HyprMXAdapterBannerAd: HyprMXAdapterAd, PartnerBannerAd {
     func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.loadStarted)
         guard let requestedSize = request.bannerSize,
-              let loadedSize = fixedBannerSize(for: requestedSize) else {
+              let loadedSize = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize)?.size else {
             let loadError = error(.loadFailureInvalidBannerSize)
             log(.loadFailed(loadError))
             completion(.failure(loadError))
@@ -74,21 +74,5 @@ extension HyprMXAdapterBannerAd: HyprMXBannerDelegate {
     // Called when a banner click will open another application
     func adWillLeaveApplication(_ bannerView: HyprMXBannerView) {
         log(.delegateCallIgnored)
-    }
-}
-
-extension HyprMXAdapterBannerAd {
-    private func fixedBannerSize(for requestedSize: BannerSize) -> CGSize? {
-        let sizes = [IABLeaderboardAdSize, IABMediumAdSize, IABStandardAdSize]
-        // Find the largest size that can fit in the requested size.
-        for size in sizes {
-            // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.size.width >= size.width &&
-                (size.height == 0 || requestedSize.size.height >= size.height) {
-                return size
-            }
-        }
-        // The requested size cannot fit any fixed size banners.
-        return nil
     }
 }

--- a/Source/HyprMXAdapterConfiguration.swift
+++ b/Source/HyprMXAdapterConfiguration.swift
@@ -18,7 +18,7 @@ import os.log
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc public static let adapterVersion = "4.6.3.0.0"
+    @objc public static let adapterVersion = "5.6.3.0.0"
 
     /// The partner's unique identifier.
     @objc public static let partnerID = "hyprmx"


### PR DESCRIPTION
Many adapters have similar code for finding the largest standard banner size that will fit within requested dimensions. This can now be replaced with BannerSize.largestStandardFixedSizeThatFits(in:)